### PR TITLE
Fixed URLs for hero.py and team.py

### DIFF
--- a/odota/hero.py
+++ b/odota/hero.py
@@ -1,6 +1,6 @@
 import requests
 
-URL = 'https://api.opendota.com/heroes/'
+URL = 'https://api.opendota.com/api/heroes/'
 
 
 class Hero(object):

--- a/odota/team.py
+++ b/odota/team.py
@@ -1,6 +1,6 @@
 import requests
 
-URL = 'https://api.opendota.com/teams/'
+URL = 'https://api.opendota.com/api/teams/'
 
 
 class Team(object):


### PR DESCRIPTION
URL for hero.py and team.py was missing 'api' and resulting in returning error